### PR TITLE
Add auto-backup, favorites, and history tracking

### DIFF
--- a/Large-Themes/start.sh
+++ b/Large-Themes/start.sh
@@ -31,15 +31,107 @@ FastCat - FastFetch Theme Pack!
 [####################] 100%%  completed.\r"
 sleep 0.2
 }
+
+# FastCat data directory
+FASTCAT_DATA="$HOME/.config/fastcat"
+mkdir -p "$FASTCAT_DATA/backups"
+
+# Auto-backup current fastfetch config before applying a new theme
+auto_backup() {
+    local src="$HOME/.config/fastfetch"
+    if [[ -d "$src" ]] && [[ "$(ls -A "$src" 2>/dev/null)" ]]; then
+        local backup_name="$FASTCAT_DATA/backups/Backup-$(date +%Y-%m-%d-%H%M%S)"
+        cp -r "$src" "$backup_name"
+        echo -e "\033[0;32mBackup saved: $backup_name\033[0m"
+        # Keep only the last 5 backups
+        local count
+        count=$(ls -1d "$FASTCAT_DATA/backups"/Backup-* 2>/dev/null | wc -l)
+        if [[ "$count" -gt 5 ]]; then
+            ls -1d "$FASTCAT_DATA/backups"/Backup-* | head -n $((count - 5)) | xargs rm -rf
+        fi
+    fi
+}
+
+# Log theme application to history
+log_history() {
+    local category="$1"
+    local theme_name="$2"
+    echo "$(date '+%Y-%m-%d %H:%M:%S')|$category|$theme_name" >> "$FASTCAT_DATA/history.log"
+    # Keep only last 50 entries
+    if [[ -f "$FASTCAT_DATA/history.log" ]]; then
+        tail -n 50 "$FASTCAT_DATA/history.log" > "$FASTCAT_DATA/history.log.tmp"
+        mv "$FASTCAT_DATA/history.log.tmp" "$FASTCAT_DATA/history.log"
+    fi
+}
+
+# Toggle favorite
+toggle_favorite() {
+    local entry="$1"
+    if grep -qxF "$entry" "$FASTCAT_DATA/favorites.txt" 2>/dev/null; then
+        grep -vxF "$entry" "$FASTCAT_DATA/favorites.txt" > "$FASTCAT_DATA/favorites.txt.tmp"
+        mv "$FASTCAT_DATA/favorites.txt.tmp" "$FASTCAT_DATA/favorites.txt"
+        echo -e "\033[1;31mRemoved from favorites: $entry\033[0m"
+    else
+        echo "$entry" >> "$FASTCAT_DATA/favorites.txt"
+        echo -e "\033[1;32mAdded to favorites: $entry\033[0m"
+    fi
+    sleep 1
+}
+
+# Show history
+show_history() {
+    if [[ ! -f "$FASTCAT_DATA/history.log" ]] || [[ ! -s "$FASTCAT_DATA/history.log" ]]; then
+        echo -e "\033[1;33mNo history yet.\033[0m"
+    else
+        echo -e "\033[1;34m--- Theme History (recent) ---\033[0m"
+        tac "$FASTCAT_DATA/history.log" | head -20 | while IFS='|' read -r date category name; do
+            echo -e "\033[0;36m$date\033[0m  \033[1;33m[$category]\033[0m  $name"
+        done
+        echo -e "\033[1;34m------------------------------\033[0m"
+    fi
+    echo -e "\033[0;36mPress any key to continue...\033[0m"
+    read -r -n1
+}
+
+# Show favorites
+show_favorites() {
+    if [[ ! -f "$FASTCAT_DATA/favorites.txt" ]] || [[ ! -s "$FASTCAT_DATA/favorites.txt" ]]; then
+        echo -e "\033[1;33mNo favorites yet. Use [+] after selecting a theme number.\033[0m"
+    else
+        echo -e "\033[1;34m--- Favorites ---\033[0m"
+        local i=1
+        while IFS='|' read -r category name; do
+            echo -e "  \033[1;33m$i)\033[0m \033[0;36m[$category]\033[0m $name"
+            ((i++))
+        done < "$FASTCAT_DATA/favorites.txt"
+        echo -e "\033[1;34m-----------------\033[0m"
+    fi
+    echo -e "\033[0;36mPress any key to continue...\033[0m"
+    read -r -n1
+}
+
+# Theme name mapping
+THEMES=(
+    [1]="Anime-Boy" [2]="Death" [3]="Pentagram" [4]="Scorpion"
+    [5]="Anime-Girl" [6]="Saturn" [7]="Suse-Icons" [8]="Cat"
+    [9]="Jurassic" [10]="BatMan" [11]="Groups" [12]="Rose"
+    [13]="Fedora" [14]="Arch" [15]="Hyprland" [16]="Simpsons"
+    [17]="Origami" [18]="Home" [19]="DeadPool" [20]="Superman"
+    [21]="Spider-Man" [22]="Triangle" [23]="Stars" [24]="Yandere-Girl"
+    [25]="TheLead" [26]="ShirazTux" [27]="Kaviani-Derafsh" [28]="Arthur-Morgan-hat"
+    [29]="MetoCat" [30]="Shiraz-Linux" [31]="Bulla-Cachy"
+)
+CATEGORY="Large"
+
 clear
 banner(){
 echo -e '\033[0;36m
-\033[0;31m______        _   _____       _   
-\033[0;33m|  ___|      | | /  __ \     | |  
-\033[0;34m| |_ __ _ ___| |_| /  \/ __ _| |_ 
+\033[0;31m______        _   _____       _
+\033[0;33m|  ___|      | | /  __ \     | |
+\033[0;34m| |_ __ _ ___| |_| /  \/ __ _| |_
 \033[0;35m|  _/ _` / __| __| |    / _` | __|\033[0;31mLarge-Themes
-\033[0;36m| || (_| \__ \ |_| \__/\ (_| | |_ 
-\033[0;31m\_| \__,_|___/\__|\____/\__,_|\__|                 
+\033[0;36m| || (_| \__ \ |_| \__/\ (_| | |_
+\033[0;31m\_| \__,_|___/\__|\____/\__,_|\__|
 \e[1;34m[01]\e[0;32mAnime-Boy \e[1;35m[02]\e[0;32mDeath \e[1;31m[03]\e[0;32mPentagram \033[1;33m[04]\e[0;32mScorpion
 \033[1;33m[05]\e[0;32mAnime-Girl \e[1;36m[06]\e[0;32mSaturn \e[1;35m[07]\e[0;32mSuse-Icons \033[0;36m[08]\e[0;32mCat
 \e[1;35m[09]\e[0;32mJurassic \033[1;33m[10]\e[0;32mBatMan \e[1;34m[11]\e[0;32mGroups \e[1;31m[12]\e[0;32mRose
@@ -48,6 +140,7 @@ echo -e '\033[0;36m
 \e[1;34m[21]\e[0;32mSpider-Man \e[0;36m[22]\e[0;32mTriangle \033[1;33m[23]\e[0;32mStars \e[1;35m[24]\e[0;32mYandere-Girl
 \e[1;34m[25]\e[0;32mTheLead \e[1;35m[26]\e[0;32mShirazTux \e[1;31m[27]\e[0;32mKaviani-Derafsh \e[1;35m[28]\e[0;32mArthur-Morgan-hat
 \e[1;31m[29]\e[0;32mMetoCat \e[1;33m[30]\e[0;32mShiraz-Linux \e[1;35m[31]\e[0;32mBulla-Cachy
+\e[1;32m[+]\e[0;32mFavorite \e[1;36m[H]\e[0;32mHistory \e[1;33m[F]\e[0;32mFavorites
 \033[1;31m[x]Exit [00]Menu [D]Default-Theme
 '
         echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat\n\e[0;31m↳\e[1;36m " ; read islem
@@ -57,287 +150,349 @@ if [[ $islem == 1 || $islem == 01 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Anime-Boy/ && cp -r fastfetch ~/.config
-clear	
+log_history "Large" "Anime-Boy"
+clear
 fastfetch
 elif [[ $islem == 2 || $islem == 02 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Death/ && cp -r fastfetch ~/.config
-clear	
+log_history "Large" "Death"
+clear
 fastfetch
 elif [[ $islem == 3 || $islem == 03 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Pentagram/ && cp -r fastfetch ~/.config
+log_history "Large" "Pentagram"
 clear
 fastfetch
 elif [[ $islem == 4 || $islem == 04 ]]; then
         sleep 1
         clear
         loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Scorpion/ && cp -r fastfetch ~/.config
-clear   
+log_history "Large" "Scorpion"
+clear
 fastfetch
 elif [[ $islem == 5 || $islem == 05 ]]; then
         sleep 1
         clear
         loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Anime-Girl/ && cp -r fastfetch ~/.config
-clear   
+log_history "Large" "Anime-Girl"
+clear
 fastfetch
 elif [[ $islem == 6 || $islem == 06 ]]; then
         sleep 1
         clear
         loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Saturn/ && cp -r fastfetch ~/.config
-clear   
+log_history "Large" "Saturn"
+clear
 fastfetch
 elif [[ $islem == 7 || $islem == 07 ]]; then
         sleep 1
         clear
         loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Suse-Icons/ && cp -r fastfetch ~/.config
-clear   
+log_history "Large" "Suse-Icons"
+clear
 fastfetch
 elif [[ $islem == 8 || $islem == 08 ]]; then
         sleep 1
         clear
         loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Cat/ && cp -r fastfetch ~/.config
-clear   
+log_history "Large" "Cat"
+clear
 fastfetch
 elif [[ $islem == 9 || $islem == 09 ]]; then
         sleep 1
         clear
         loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Jurassic/ && cp -r fastfetch ~/.config
-clear   
+log_history "Large" "Jurassic"
+clear
 fastfetch
 elif [[ $islem == 10 ]]; then
         sleep 1
         clear
         loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd BatMan/ && cp -r fastfetch ~/.config
-clear   
+log_history "Large" "BatMan"
+clear
 fastfetch
 elif [[ $islem == 11 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Groups/ && cp -r fastfetch ~/.config
+log_history "Large" "Groups"
 clear
 fastfetch
 elif [[ $islem == 12 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Rose/ && cp -r fastfetch ~/.config
+log_history "Large" "Rose"
 clear
 fastfetch
 elif [[ $islem == 13 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Fedora/ && cp -r fastfetch ~/.config
+log_history "Large" "Fedora"
 clear
 fastfetch
 elif [[ $islem == 14 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Arch/ && cp -r fastfetch ~/.config
+log_history "Large" "Arch"
 clear
 fastfetch
 elif [[ $islem == 15 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Hyprland/ && cp -r fastfetch ~/.config
+log_history "Large" "Hyprland"
 clear
 fastfetch
 elif [[ $islem == 16 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Simpsons/ && cp -r fastfetch ~/.config
+log_history "Large" "Simpsons"
 clear
 fastfetch
 elif [[ $islem == 17 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Origami/ && cp -r fastfetch ~/.config
+log_history "Large" "Origami"
 clear
 fastfetch
 elif [[ $islem == 18 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Home/ && cp -r fastfetch ~/.config
+log_history "Large" "Home"
 clear
 fastfetch
 elif [[ $islem == 19 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd DeadPool/ && cp -r fastfetch ~/.config
+log_history "Large" "DeadPool"
 clear
 fastfetch
 elif [[ $islem == 20 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Superman/ && cp -r fastfetch ~/.config
+log_history "Large" "Superman"
 clear
 fastfetch
 elif [[ $islem == 21 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Spider-Man/ && cp -r fastfetch ~/.config
+log_history "Large" "Spider-Man"
 clear
 fastfetch
 elif [[ $islem == 22 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Triangle/ && cp -r fastfetch ~/.config
+log_history "Large" "Triangle"
 clear
 fastfetch
 elif [[ $islem == 23 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Stars/ && cp -r fastfetch ~/.config
+log_history "Large" "Stars"
 clear
 fastfetch
 elif [[ $islem == 24 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Yandere-Girl/ && cp -r fastfetch ~/.config
+log_history "Large" "Yandere-Girl"
 clear
 fastfetch
 elif [[ $islem == 25 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch/
 sleep 1
 		mkdir -p ~/.config/fastfetch/
         cd TheLead/ && cp -r fastfetch ~/.config
+log_history "Large" "TheLead"
 clear
 fastfetch
 elif [[ $islem == 26 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
 mkdir -p ~/.config/fastfetch/
         cd ShirazTux/ && cp -r fastfetch ~/.config
+log_history "Large" "ShirazTux"
 clear
 fastfetch
 elif [[ $islem == 27 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
 mkdir -p ~/.config/fastfetch/
         cd Kaviani-Derafsh/ && cp -r fastfetch ~/.config
+log_history "Large" "Kaviani-Derafsh"
 clear
 fastfetch
 elif [[ $islem == 28 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
 mkdir -p ~/.config/fastfetch/
 mv "Arthur-Morgan's-hat" "Arthur-Morgan-hat"
 cd    Arthur-Morgan-hat/ && cp -r fastfetch ~/.config
+log_history "Large" "Arthur-Morgan-hat"
 clear
 fastfetch
 elif [[ $islem == 29 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch/
 sleep 1
 		mkdir -p ~/.config/fastfetch/
         cd MetoCat/ && cp -r fastfetch ~/.config
+log_history "Large" "MetoCat"
 clear
 fastfetch
 elif [[ $islem == 30 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch/
 sleep 1
 		mkdir -p ~/.config/fastfetch/
         cd Shiraz-Linux/ && cp -r fastfetch ~/.config
+log_history "Large" "Shiraz-Linux"
 clear
 fastfetch
 elif [[ $islem == 31 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch/
 sleep 1
 		mkdir -p ~/.config/fastfetch/
         cd Bulla-Cachy/ && cp -r fastfetch ~/.config
+log_history "Large" "Bulla-Cachy"
 clear
 fastfetch
 elif [[  $islem == 00 ]]; then
@@ -348,15 +503,34 @@ elif [[ $islem == D || $islem == d  ]]; then
         sleep 1
         clear
         loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Default/ && cp -r fastfetch ~/.config
-clear   
+log_history "Large" "Default"
+clear
 fastfetch
+elif [[ $islem == "+" ]]; then
+    echo -e "\033[1;33mEnter theme number to toggle favorite:\033[0m"
+    echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat\n\e[0;31m↳\e[1;36m " ; read fav_num
+    fav_num=$((10#$fav_num))
+    if [[ -n "${THEMES[$fav_num]+x}" ]]; then
+        toggle_favorite "$CATEGORY|${THEMES[$fav_num]}"
+    else
+        echo -e "\033[1;31mInvalid theme number!\033[0m"
+        sleep 1
+    fi
+    exec bash "$0"
+elif [[ $islem == H || $islem == h ]]; then
+    show_history
+    exec bash "$0"
+elif [[ $islem == F || $islem == f ]]; then
+    show_favorites
+    exec bash "$0"
 elif [[ $islem == x || $islem == X ]]; then
 	clear
 echo -e "\033[1;31m GoodBye\033[0m"
 	exit 1
 else
-	echo -e '\033[36;40;1m Wrong transaction number!'	
+	echo -e '\033[36;40;1m Wrong transaction number!'
 fi

--- a/Small-Themes/start.sh
+++ b/Small-Themes/start.sh
@@ -31,19 +31,108 @@ FastCat - FastFetch Theme Pack!
 [####################] 100%%  completed.\r"
 sleep 0.2
 }
+
+# FastCat data directory
+FASTCAT_DATA="$HOME/.config/fastcat"
+mkdir -p "$FASTCAT_DATA/backups"
+
+# Auto-backup current fastfetch config before applying a new theme
+auto_backup() {
+    local src="$HOME/.config/fastfetch"
+    if [[ -d "$src" ]] && [[ "$(ls -A "$src" 2>/dev/null)" ]]; then
+        local backup_name="$FASTCAT_DATA/backups/Backup-$(date +%Y-%m-%d-%H%M%S)"
+        cp -r "$src" "$backup_name"
+        echo -e "\033[0;32mBackup saved: $backup_name\033[0m"
+        # Keep only the last 5 backups
+        local count
+        count=$(ls -1d "$FASTCAT_DATA/backups"/Backup-* 2>/dev/null | wc -l)
+        if [[ "$count" -gt 5 ]]; then
+            ls -1d "$FASTCAT_DATA/backups"/Backup-* | head -n $((count - 5)) | xargs rm -rf
+        fi
+    fi
+}
+
+# Log theme application to history
+log_history() {
+    local category="$1"
+    local theme_name="$2"
+    echo "$(date '+%Y-%m-%d %H:%M:%S')|$category|$theme_name" >> "$FASTCAT_DATA/history.log"
+    # Keep only last 50 entries
+    if [[ -f "$FASTCAT_DATA/history.log" ]]; then
+        tail -n 50 "$FASTCAT_DATA/history.log" > "$FASTCAT_DATA/history.log.tmp"
+        mv "$FASTCAT_DATA/history.log.tmp" "$FASTCAT_DATA/history.log"
+    fi
+}
+
+# Toggle favorite
+toggle_favorite() {
+    local entry="$1"
+    if grep -qxF "$entry" "$FASTCAT_DATA/favorites.txt" 2>/dev/null; then
+        grep -vxF "$entry" "$FASTCAT_DATA/favorites.txt" > "$FASTCAT_DATA/favorites.txt.tmp"
+        mv "$FASTCAT_DATA/favorites.txt.tmp" "$FASTCAT_DATA/favorites.txt"
+        echo -e "\033[1;31mRemoved from favorites: $entry\033[0m"
+    else
+        echo "$entry" >> "$FASTCAT_DATA/favorites.txt"
+        echo -e "\033[1;32mAdded to favorites: $entry\033[0m"
+    fi
+    sleep 1
+}
+
+# Show history
+show_history() {
+    if [[ ! -f "$FASTCAT_DATA/history.log" ]] || [[ ! -s "$FASTCAT_DATA/history.log" ]]; then
+        echo -e "\033[1;33mNo history yet.\033[0m"
+    else
+        echo -e "\033[1;34m--- Theme History (recent) ---\033[0m"
+        tac "$FASTCAT_DATA/history.log" | head -20 | while IFS='|' read -r date category name; do
+            echo -e "\033[0;36m$date\033[0m  \033[1;33m[$category]\033[0m  $name"
+        done
+        echo -e "\033[1;34m------------------------------\033[0m"
+    fi
+    echo -e "\033[0;36mPress any key to continue...\033[0m"
+    read -r -n1
+}
+
+# Show favorites
+show_favorites() {
+    if [[ ! -f "$FASTCAT_DATA/favorites.txt" ]] || [[ ! -s "$FASTCAT_DATA/favorites.txt" ]]; then
+        echo -e "\033[1;33mNo favorites yet. Use [+] after selecting a theme number.\033[0m"
+    else
+        echo -e "\033[1;34m--- Favorites ---\033[0m"
+        local i=1
+        while IFS='|' read -r category name; do
+            echo -e "  \033[1;33m$i)\033[0m \033[0;36m[$category]\033[0m $name"
+            ((i++))
+        done < "$FASTCAT_DATA/favorites.txt"
+        echo -e "\033[1;34m-----------------\033[0m"
+    fi
+    echo -e "\033[0;36mPress any key to continue...\033[0m"
+    read -r -n1
+}
+
+# Theme name mapping
+THEMES=(
+    [1]="MetoSpace" [2]="Fast-Snail" [3]="Cat" [4]="Minimal"
+    [5]="Arch" [6]="Blocks" [7]="Cocktail" [8]="Palm"
+    [9]="Sheriff" [10]="Bunny" [11]="Coffee" [12]="Duck"
+    [13]="OWL" [14]="Giraffe" [15]="Robo-Dog" [16]="Tie-Fighter"
+)
+CATEGORY="Small"
+
 clear
 banner(){
 echo -e '\033[0;36m
-\033[0;31m______        _   _____       _   
-\033[0;33m|  ___|      | | /  __ \     | |  
-\033[0;34m| |_ __ _ ___| |_| /  \/ __ _| |_ 
+\033[0;31m______        _   _____       _
+\033[0;33m|  ___|      | | /  __ \     | |
+\033[0;34m| |_ __ _ ___| |_| /  \/ __ _| |_
 \033[0;35m|  _/ _` / __| __| |    / _` | __|\033[0;31mSmall-Themes
-\033[0;36m| || (_| \__ \ |_| \__/\ (_| | |_ 
-\033[0;31m\_| \__,_|___/\__|\____/\__,_|\__|                 
+\033[0;36m| || (_| \__ \ |_| \__/\ (_| | |_
+\033[0;31m\_| \__,_|___/\__|\____/\__,_|\__|
 \e[1;34m[01]\e[0;32mMetoSpace \e[1;35m[02]\e[0;32mFast-Snail \e[1;36m[03]\e[0;32mCat \e[1;31m[04]\e[0;32mMinimal
-\e[1;33m[05]\e[0;32mArch \e[1;36m[06]\e[0;32mBlocks \e[1;34m[07]\e[0;32mCocktail \033[1;33m[08]\e[0;32mPalm \033[0;36m[09]\e[0;32mSheriff 
+\e[1;33m[05]\e[0;32mArch \e[1;36m[06]\e[0;32mBlocks \e[1;34m[07]\e[0;32mCocktail \033[1;33m[08]\e[0;32mPalm \033[0;36m[09]\e[0;32mSheriff
 \e[1;35m[10]\e[0;32mBunny \e[1;34m[11]\e[0;32mCoffee \e[1;35m[12]\e[0;32mDuck \033[1;33m[13]\e[0;32mOWL \e[1;34m[14]\e[0;32mGiraffe
 \e[1;36m[15]\e[0;32mRobo-Dog \e[1;34m[16]\e[0;32mTie-Fighter
+\e[1;32m[+]\e[0;32mFavorite \e[1;36m[H]\e[0;32mHistory \e[1;33m[F]\e[0;32mFavorites
 \033[1;31m[x]Exit [00]Menu [D]Default-Theme
 '
         echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat\n\e[0;31m↳\e[1;36m " ; read islem
@@ -53,145 +142,177 @@ if [[ $islem == 1 || $islem == 01 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd MetoSpace/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "MetoSpace"
+clear
 fastfetch
 elif [[ $islem == 2 || $islem == 02 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Fast-Snail/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "Fast-Snail"
+clear
 fastfetch
 elif [[ $islem == 3 || $islem == 03 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Cat/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "Cat"
+clear
 fastfetch
 elif [[ $islem == 4 || $islem == 04 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Minimal/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "Minimal"
+clear
 fastfetch
 elif [[ $islem == 5 || $islem == 05 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Arch/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "Arch"
+clear
 fastfetch
 elif [[ $islem == 6 || $islem == 06 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Blocks/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "Blocks"
+clear
 fastfetch
 elif [[ $islem == 7 || $islem == 07 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Cocktail/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "Cocktail"
+clear
 fastfetch
 elif [[ $islem == 8 || $islem == 08 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Palm/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "Palm"
+clear
 fastfetch
 elif [[ $islem == 9 || $islem == 09 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Sheriff/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "Sheriff"
+clear
 fastfetch
 elif [[ $islem == 10 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Bunny/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "Bunny"
+clear
 fastfetch
 elif [[ $islem == 11 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Coffee/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "Coffee"
+clear
 fastfetch
 elif [[ $islem == 12 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Duck/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "Duck"
+clear
 fastfetch
 elif [[ $islem == 13 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd OWL/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "OWL"
+clear
 fastfetch
 elif [[ $islem == 14 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Giraffe/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "Giraffe"
+clear
 fastfetch
 elif [[ $islem == 15 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Robo-Dog/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "Robo-Dog"
+clear
 fastfetch
 elif [[ $islem == 16 ]]; then
 	sleep 1
 	clear
 	loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Tie-Fighter/ && cp -r fastfetch ~/.config
-clear	
+log_history "Small" "Tie-Fighter"
+clear
 fastfetch
 elif [[  $islem == 00 ]]; then
         sleep 1
@@ -201,15 +322,34 @@ elif [[ $islem == D || $islem == d  ]]; then
         sleep 1
         clear
         loader
+auto_backup
 rm -r ~/.config/fastfetch
 sleep 1
         cd Default/ && cp -r fastfetch ~/.config
-clear   
+log_history "Small" "Default"
+clear
 fastfetch
+elif [[ $islem == "+" ]]; then
+    echo -e "\033[1;33mEnter theme number to toggle favorite:\033[0m"
+    echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat\n\e[0;31m↳\e[1;36m " ; read fav_num
+    fav_num=$((10#$fav_num))
+    if [[ -n "${THEMES[$fav_num]+x}" ]]; then
+        toggle_favorite "$CATEGORY|${THEMES[$fav_num]}"
+    else
+        echo -e "\033[1;31mInvalid theme number!\033[0m"
+        sleep 1
+    fi
+    exec bash "$0"
+elif [[ $islem == H || $islem == h ]]; then
+    show_history
+    exec bash "$0"
+elif [[ $islem == F || $islem == f ]]; then
+    show_favorites
+    exec bash "$0"
 elif [[ $islem == x || $islem == X ]]; then
 	clear
 echo -e "\033[1;31m GoodBye\033[0m"
 	exit 1
 else
-	echo -e '\033[36;40;1m Wrong transaction number!'	
+	echo -e '\033[36;40;1m Wrong transaction number!'
 fi

--- a/fastcat.sh
+++ b/fastcat.sh
@@ -135,7 +135,7 @@ echo -e '\033[1;36m
 '
 echo -e '
 \e[1;34m[01]\e[0;32mSmall Themes \e[1;35m[02]\e[0;32mLarge Themes \e[1;33m[03]\e[0;32mVisuals Themes \033[0;33m[C]\e[0;32mCommunity Themes 
-\e[1;31m[A]About [B]Backup [x]Exit\033[0m
+\e[1;31m[A]About [B]Backup \e[1;36m[H]History [F]Favorites \e[1;31m[x]Exit\033[0m
 '
         echo -ne "\e[1;31mm3tozz\033[0;36m@\033[1;33mfastcat\n\e \033[0;36m↳\033[0m " ; read islem
 }
@@ -190,6 +190,34 @@ echo -e '
     read -r -n1
     shell
     
+elif [[ $islem == h || $islem == H ]]; then
+    FASTCAT_DATA="$HOME/.config/fastcat"
+    if [[ ! -f "$FASTCAT_DATA/history.log" ]] || [[ ! -s "$FASTCAT_DATA/history.log" ]]; then
+        echo -e "\033[1;33mNo history yet.\033[0m"
+    else
+        echo -e "\033[1;34m--- Theme History ---\033[0m"
+        tac "$FASTCAT_DATA/history.log" | head -20 | while IFS='|' read -r date category name; do
+            echo -e "\033[0;36m$date\033[0m  \033[1;33m[$category]\033[0m  $name"
+        done
+        echo -e "\033[1;34m---------------------\033[0m"
+    fi
+    echo -e "\nPress any key to continue..."
+    read -r -n1
+    shell
+elif [[ $islem == f || $islem == F ]]; then
+    FASTCAT_DATA="$HOME/.config/fastcat"
+    if [[ ! -f "$FASTCAT_DATA/favorites.txt" ]] || [[ ! -s "$FASTCAT_DATA/favorites.txt" ]]; then
+        echo -e "\033[1;33mNo favorites yet.\033[0m"
+    else
+        echo -e "\033[1;34m--- Favorites ---\033[0m"
+        while IFS='|' read -r category name; do
+            echo -e "  \033[0;36m[$category]\033[0m $name"
+        done < "$FASTCAT_DATA/favorites.txt"
+        echo -e "\033[1;34m-----------------\033[0m"
+    fi
+    echo -e "\nPress any key to continue..."
+    read -r -n1
+    shell
 elif [[ $islem == b || $islem == B ]]; then
 $SHELL ./backup.sh
 else


### PR DESCRIPTION
## Summary
- **Auto-backup**: Automatically backs up `~/.config/fastfetch` before applying any theme (keeps last 5 backups, auto-prunes older ones)
- **Favorites**: Mark themes with `[+]`, view with `[F]` — persisted across sessions in `~/.config/fastcat/favorites.txt`
- **History**: Every theme applied is logged with timestamp — view with `[H]` from any menu

## Data storage
All persistent data in `~/.config/fastcat/`:
- `favorites.txt` — format: `category|ThemeName`
- `history.log` — format: `YYYY-MM-DD HH:MM:SS|category|ThemeName` (last 50 entries)
- `backups/` — timestamped directories, max 5

## Why
- Users lose their config every time they switch themes with no safety net
- No way to bookmark themes you like across sessions
- No way to remember which themes you've tried

## Test plan
- [ ] Apply a theme and verify backup is created in `~/.config/fastcat/backups/`
- [ ] Apply 6+ themes and verify only 5 backups remain
- [ ] Toggle favorite with `[+]` and verify it appears in `[F]`
- [ ] Toggle same favorite again to remove it
- [ ] Apply themes and verify `[H]` shows history with timestamps
- [ ] Test from main menu (`fastcat.sh`) `[H]` and `[F]` options
- [ ] Test on macOS