### PR TITLE
Add search and random theme selection

### DIFF
--- a/Large-Themes/start.sh
+++ b/Large-Themes/start.sh
@@ -31,6 +31,98 @@ FastCat - FastFetch Theme Pack!
 [####################] 100%%  completed.\r"
 sleep 0.2
 }
+
+# Theme directory mapping
+THEMES=(
+    [1]="Anime-Boy" [2]="Death" [3]="Pentagram" [4]="Scorpion"
+    [5]="Anime-Girl" [6]="Saturn" [7]="Suse-Icons" [8]="Cat"
+    [9]="Jurassic" [10]="BatMan" [11]="Groups" [12]="Rose"
+    [13]="Fedora" [14]="Arch" [15]="Hyprland" [16]="Simpsons"
+    [17]="Origami" [18]="Home" [19]="DeadPool" [20]="Superman"
+    [21]="Spider-Man" [22]="Triangle" [23]="Stars" [24]="Yandere-Girl"
+    [25]="TheLead" [26]="ShirazTux" [27]="Kaviani-Derafsh" [28]="Arthur-Morgan-hat"
+    [29]="MetoCat" [30]="Shiraz-Linux" [31]="Bulla-Cachy"
+)
+THEME_COUNT=31
+
+# Apply a theme by directory name
+apply_by_name() {
+    local theme_name="$1"
+    local theme_dir="$theme_name"
+
+    # Handle special case: Arthur-Morgan's-hat
+    if [[ "$theme_name" == "Arthur-Morgan-hat" ]] && [[ -d "Arthur-Morgan's-hat" ]] && [[ ! -d "Arthur-Morgan-hat" ]]; then
+        mv "Arthur-Morgan's-hat" "Arthur-Morgan-hat"
+    fi
+
+    sleep 1
+    clear
+    loader
+    rm -r ~/.config/fastfetch
+    sleep 1
+    mkdir -p ~/.config/fastfetch/
+    cd "$theme_dir/" && cp -r fastfetch ~/.config
+    clear
+    fastfetch
+}
+
+# Pick a random theme
+random_theme() {
+    local rand=$((RANDOM % THEME_COUNT + 1))
+    local name="${THEMES[$rand]}"
+    echo -e "\033[1;33mRandom pick: \033[1;32m$name\033[0m"
+    sleep 1
+    apply_by_name "$name"
+}
+
+# Search themes by name
+search_themes() {
+    echo -e "\033[1;33mSearch theme:\033[0m"
+    echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat\n\e[0;31m↳\e[1;36m " ; read query
+
+    if [[ -z "$query" ]]; then
+        echo -e "\033[1;31mEmpty search.\033[0m"
+        sleep 1
+        return
+    fi
+
+    local found=0
+    local matches=()
+    local match_nums=()
+
+    for i in "${!THEMES[@]}"; do
+        if echo "${THEMES[$i]}" | grep -qi "$query"; then
+            matches+=("${THEMES[$i]}")
+            match_nums+=("$i")
+            ((found++))
+        fi
+    done
+
+    if [[ $found -eq 0 ]]; then
+        echo -e "\033[1;31mNo themes found matching '$query'\033[0m"
+        sleep 2
+        return
+    fi
+
+    echo -e "\033[1;34m--- Search Results ---\033[0m"
+    for idx in "${!matches[@]}"; do
+        echo -e "  \033[1;33m[${match_nums[$idx]}]\033[0m ${matches[$idx]}"
+    done
+    echo -e "\033[1;34m----------------------\033[0m"
+    echo -e "\033[0;36mEnter number to apply, or press Enter to go back:\033[0m"
+    echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat\n\e[0;31m↳\e[1;36m " ; read choice
+
+    if [[ -n "$choice" ]]; then
+        choice=$((10#$choice))
+        if [[ -n "${THEMES[$choice]+x}" ]]; then
+            apply_by_name "${THEMES[$choice]}"
+        else
+            echo -e "\033[1;31mInvalid number!\033[0m"
+            sleep 1
+        fi
+    fi
+}
+
 clear
 banner(){
 echo -e '\033[0;36m
@@ -48,7 +140,7 @@ echo -e '\033[0;36m
 \e[1;34m[21]\e[0;32mSpider-Man \e[0;36m[22]\e[0;32mTriangle \033[1;33m[23]\e[0;32mStars \e[1;35m[24]\e[0;32mYandere-Girl
 \e[1;34m[25]\e[0;32mTheLead \e[1;35m[26]\e[0;32mShirazTux \e[1;31m[27]\e[0;32mKaviani-Derafsh \e[1;35m[28]\e[0;32mArthur-Morgan-hat
 \e[1;31m[29]\e[0;32mMetoCat \e[1;33m[30]\e[0;32mShiraz-Linux \e[1;35m[31]\e[0;32mBulla-Cachy
-\033[1;31m[x]Exit [00]Menu [D]Default-Theme
+\e[1;32m[R]\e[0;32mRandom \e[1;36m[/]\e[0;32mSearch \033[1;31m[x]Exit [00]Menu [D]Default-Theme
 '
         echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat\n\e[0;31m↳\e[1;36m " ; read islem
 }
@@ -353,6 +445,11 @@ sleep 1
         cd Default/ && cp -r fastfetch ~/.config
 clear   
 fastfetch
+elif [[ $islem == R || $islem == r ]]; then
+    random_theme
+elif [[ $islem == "/" ]]; then
+    search_themes
+    exec bash "$0"
 elif [[ $islem == x || $islem == X ]]; then
 	clear
 echo -e "\033[1;31m GoodBye\033[0m"

--- a/Small-Themes/start.sh
+++ b/Small-Themes/start.sh
@@ -31,6 +31,86 @@ FastCat - FastFetch Theme Pack!
 [####################] 100%%  completed.\r"
 sleep 0.2
 }
+
+# Theme directory mapping
+THEMES=(
+    [1]="MetoSpace" [2]="Fast-Snail" [3]="Cat" [4]="Minimal"
+    [5]="Arch" [6]="Blocks" [7]="Cocktail" [8]="Palm"
+    [9]="Sheriff" [10]="Bunny" [11]="Coffee" [12]="Duck"
+    [13]="OWL" [14]="Giraffe" [15]="Robo-Dog" [16]="Tie-Fighter"
+)
+THEME_COUNT=16
+
+# Apply a theme by directory name
+apply_by_name() {
+    local theme_name="$1"
+    sleep 1
+    clear
+    loader
+    rm -r ~/.config/fastfetch
+    sleep 1
+    cd "$theme_name/" && cp -r fastfetch ~/.config
+    clear
+    fastfetch
+}
+
+# Pick a random theme
+random_theme() {
+    local rand=$((RANDOM % THEME_COUNT + 1))
+    local name="${THEMES[$rand]}"
+    echo -e "\033[1;33mRandom pick: \033[1;32m$name\033[0m"
+    sleep 1
+    apply_by_name "$name"
+}
+
+# Search themes by name
+search_themes() {
+    echo -e "\033[1;33mSearch theme:\033[0m"
+    echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat\n\e[0;31m↳\e[1;36m " ; read query
+
+    if [[ -z "$query" ]]; then
+        echo -e "\033[1;31mEmpty search.\033[0m"
+        sleep 1
+        return
+    fi
+
+    local found=0
+    local matches=()
+    local match_nums=()
+
+    for i in "${!THEMES[@]}"; do
+        if echo "${THEMES[$i]}" | grep -qi "$query"; then
+            matches+=("${THEMES[$i]}")
+            match_nums+=("$i")
+            ((found++))
+        fi
+    done
+
+    if [[ $found -eq 0 ]]; then
+        echo -e "\033[1;31mNo themes found matching '$query'\033[0m"
+        sleep 2
+        return
+    fi
+
+    echo -e "\033[1;34m--- Search Results ---\033[0m"
+    for idx in "${!matches[@]}"; do
+        echo -e "  \033[1;33m[${match_nums[$idx]}]\033[0m ${matches[$idx]}"
+    done
+    echo -e "\033[1;34m----------------------\033[0m"
+    echo -e "\033[0;36mEnter number to apply, or press Enter to go back:\033[0m"
+    echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat\n\e[0;31m↳\e[1;36m " ; read choice
+
+    if [[ -n "$choice" ]]; then
+        choice=$((10#$choice))
+        if [[ -n "${THEMES[$choice]+x}" ]]; then
+            apply_by_name "${THEMES[$choice]}"
+        else
+            echo -e "\033[1;31mInvalid number!\033[0m"
+            sleep 1
+        fi
+    fi
+}
+
 clear
 banner(){
 echo -e '\033[0;36m
@@ -44,7 +124,7 @@ echo -e '\033[0;36m
 \e[1;33m[05]\e[0;32mArch \e[1;36m[06]\e[0;32mBlocks \e[1;34m[07]\e[0;32mCocktail \033[1;33m[08]\e[0;32mPalm \033[0;36m[09]\e[0;32mSheriff 
 \e[1;35m[10]\e[0;32mBunny \e[1;34m[11]\e[0;32mCoffee \e[1;35m[12]\e[0;32mDuck \033[1;33m[13]\e[0;32mOWL \e[1;34m[14]\e[0;32mGiraffe
 \e[1;36m[15]\e[0;32mRobo-Dog \e[1;34m[16]\e[0;32mTie-Fighter
-\033[1;31m[x]Exit [00]Menu [D]Default-Theme
+\e[1;32m[R]\e[0;32mRandom \e[1;36m[/]\e[0;32mSearch \033[1;31m[x]Exit [00]Menu [D]Default-Theme
 '
         echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat\n\e[0;31m↳\e[1;36m " ; read islem
 }
@@ -206,6 +286,11 @@ sleep 1
         cd Default/ && cp -r fastfetch ~/.config
 clear   
 fastfetch
+elif [[ $islem == R || $islem == r ]]; then
+    random_theme
+elif [[ $islem == "/" ]]; then
+    search_themes
+    exec bash "$0"
 elif [[ $islem == x || $islem == X ]]; then
 	clear
 echo -e "\033[1;31m GoodBye\033[0m"

--- a/Visuals-Themes/start.sh
+++ b/Visuals-Themes/start.sh
@@ -30,6 +30,12 @@ loader() {
   sleep 0.2
 }
 
+# Theme directory mapping
+THEMES=(
+    [1]="Dragonball" [2]="One-Piece" [3]="Xenia"
+)
+THEME_COUNT=3
+
 # Prompts the user to select the image rendering protocol with details.
 # This is now called AFTER a theme is selected.
 prompt_logo_protocol() {
@@ -104,7 +110,7 @@ banner() {
 \033[0;31m\_| \__,_|___/\__|\____/\__,_|\__|     
 \e[1;34m[01]\e[0;32mDragonball \e[1;35m[02]\e[0;32mOne-Piece \e[1;31m[03]\e[0;32mXenia
 \e[3m\e[92mThese themes require an image-supporting terminal emulator.\e[0m
-\033[1;31m[x]Exit  [00]Menu  [D]Default-Theme
+\e[1;32m[R]\e[0;32mRandom \e[1;36m[/]\e[0;32mSearch \033[1;31m[x]Exit  [00]Menu  [D]Default-Theme
 '
 }
 
@@ -134,6 +140,35 @@ while true; do
             cd ..
             bash ./fastcat.sh -s
             break
+            ;;
+        R|r)
+            local rand=$((RANDOM % THEME_COUNT + 1))
+            local name="${THEMES[$rand]}"
+            echo -e "\033[1;33mRandom pick: \033[1;32m$name\033[0m"
+            sleep 1
+            prompt_logo_protocol
+            apply_visual_theme "$name"
+            break
+            ;;
+        "/")
+            echo -e "\033[1;33mSearch theme:\033[0m"
+            echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat\n\e[0;31m↳\e[1;36m " ; read query
+            if [[ -z "$query" ]]; then
+                echo -e "\033[1;31mEmpty search.\033[0m"
+                sleep 1
+            else
+                local found=0
+                for i in "${!THEMES[@]}"; do
+                    if echo "${THEMES[$i]}" | grep -qi "$query"; then
+                        echo -e "  \033[1;33m[$i]\033[0m ${THEMES[$i]}"
+                        ((found++))
+                    fi
+                done
+                if [[ $found -eq 0 ]]; then
+                    echo -e "\033[1;31mNo themes found matching '$query'\033[0m"
+                fi
+                sleep 2
+            fi
             ;;
         D|d)
             echo -e "\n\033[1;33mWarning: There is no 'default' for visual themes.\033[0m"


### PR DESCRIPTION
## Summary
- **Random** `[R]`: Picks a random theme from the current category and applies it instantly
- **Search** `[/]`: Case-insensitive search by theme name, shows matching results with their numbers for easy selection

## How it works
### Random
1. Press `R` at any theme menu
2. A random theme is selected and applied
3. For Visual themes, protocol selection is prompted first

### Search
1. Press `/` at any theme menu
2. Type a search term (e.g., "bat", "arch", "cat")
3. Matching themes are displayed with their numbers
4. Enter a number to apply, or press Enter to go back

## Why
With 50+ themes, scrolling through menus gets tedious. Search helps find themes by name, and random is a fun way to discover new ones.

## Test plan
- [ ] Test `[R]` in each category (Small, Large, Visual)
- [ ] Test `[/]` with partial matches (e.g., "cat" finds "Cat" and "MetoCat")
- [ ] Test `[/]` with no matches
- [ ] Test `[/]` with empty input
- [ ] Test search result selection by number
- [ ] Test on macOS