### PR TITLE
feat: Add preview loop mode

### DIFF
--- a/Large-Themes/start.sh
+++ b/Large-Themes/start.sh
@@ -110,6 +110,44 @@ random_theme() {
     apply_by_name "$name"
 }
 
+preview_loop() {
+    while true; do
+        clear
+        echo -e "\033[1;33m--- Preview Mode -------------------------------------------\033[0m"
+        local idx=0
+        for key in $(echo "${!THEMES[@]}" | tr ' ' '\n' | sort -n); do
+            printf "  \e[1;34m[%02d]\e[0;32m %-18s\033[0m" "$key" "${THEMES[$key]}"
+            (( ++idx % 4 == 0 )) && echo
+        done
+        echo
+        echo -e "\033[1;33m------------------------------------------------------------\033[0m"
+        echo -e "\033[0;36mType a number to preview · [Q] return to menu\033[0m"
+        echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat \033[1;31m(preview)\n\e[0;31m↳\e[1;36m "
+        read -r preview_input
+
+        case "$preview_input" in
+            Q|q)
+                clear
+                break
+                ;;
+            ''|*[!0-9]*)
+                echo -e "\033[1;31mInvalid input!\033[0m"
+                sleep 1
+                ;;
+            *)
+                local choice
+                choice=$((10#$preview_input))
+                if [[ -n "${THEMES[$choice]+x}" ]]; then
+                    preview_theme "${THEMES[$choice]}"
+                else
+                    echo -e "\033[1;31mTheme #$choice not found!\033[0m"
+                    sleep 1
+                fi
+                ;;
+        esac
+    done
+}
+
 search_themes() {
     echo -e "\033[1;33mSearch theme:\033[0m"
     read -rp $'\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat\n\e[0;31m↳\e[1;36m ' query
@@ -190,15 +228,7 @@ case $islem in
         apply_by_name "${THEMES[$choice]}"
         ;;
     P|p) 
-        echo -e "\033[1;33mEnter theme number to preview:\033[0m"
-        read -r preview_num
-        preview_num=$((10#$preview_num))
-        if [[ -n "${THEMES[$preview_num]+x}" ]]; then
-            preview_theme "${THEMES[$preview_num]}"
-        else
-            echo -e "\033[1;31mInvalid theme number!\033[0m"
-            sleep 1
-        fi
+        preview_loop
         exec bash "$0"
         ;;
     R|r)

--- a/Small-Themes/start.sh
+++ b/Small-Themes/start.sh
@@ -106,6 +106,44 @@ random_theme() {
     apply_by_name "$name"
 }
 
+preview_loop() {
+    while true; do
+        clear
+        echo -e "\033[1;33m--- Preview Mode -------------------------------------------\033[0m"
+        local idx=0
+        for key in $(echo "${!THEMES[@]}" | tr ' ' '\n' | sort -n); do
+            printf "  \e[1;34m[%02d]\e[0;32m %-18s\033[0m" "$key" "${THEMES[$key]}"
+            (( ++idx % 4 == 0 )) && echo
+        done
+        echo
+        echo -e "\033[1;33m------------------------------------------------------------\033[0m"
+        echo -e "\033[0;36mType a number to preview · [Q] return to menu\033[0m"
+        echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat \033[1;31m(preview)\n\e[0;31m↳\e[1;36m "
+        read -r preview_input
+
+        case "$preview_input" in
+            Q|q)
+                clear
+                break
+                ;;
+            ''|*[!0-9]*)
+                echo -e "\033[1;31mInvalid input!\033[0m"
+                sleep 1
+                ;;
+            *)
+                local choice
+                choice=$((10#$preview_input))
+                if [[ -n "${THEMES[$choice]+x}" ]]; then
+                    preview_theme "${THEMES[$choice]}"
+                else
+                    echo -e "\033[1;31mTheme #$choice not found!\033[0m"
+                    sleep 1
+                fi
+                ;;
+        esac
+    done
+}
+
 # banner
 clear
 banner(){
@@ -135,15 +173,7 @@ case $islem in
         apply_by_name "${THEMES[$choice]}"
         ;;
     P|p) 
-        echo -e "\033[1;33mEnter theme number to preview:\033[0m"
-        read -r preview_num
-        preview_num=$((10#$preview_num))
-        if [[ -n "${THEMES[$preview_num]+x}" ]]; then
-            preview_theme "${THEMES[$preview_num]}"
-        else
-            echo -e "\033[1;31mInvalid theme number!\033[0m"
-            sleep 1
-        fi
+        preview_loop
         exec bash "$0"
         ;;
     R|r)

--- a/Visuals-Themes/start.sh
+++ b/Visuals-Themes/start.sh
@@ -152,34 +152,59 @@ while true; do
             break
             ;;
         P|p)
-            echo -e "\033[1;33mEnter theme number to preview:\033[0m"
-            echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat\n\e[0;31m↳\e[1;36m " ; read preview_num
-            preview_num=$((10#$preview_num))
-            if [[ -n "${THEMES[$preview_num]+x}" ]]; then
-                prompt_logo_protocol
-                local_theme="${THEMES[$preview_num]}"
-                tmp_dir=$(mktemp -d)
-                cp -r "$local_theme/fastfetch/"* "$tmp_dir/"
-                config="$tmp_dir/config.jsonc"
-                # Fix image protocol
-                if [[ "$(uname)" == "Darwin" ]]; then
-                    sed -i '' '/"logo": {/,/}/s/"type": ".*"/"type": "'"$LOGO_PROTOCOL"'"/' "$config"
-                    sed -i '' "s|\"source\": \"|\"source\": \"$tmp_dir/|g" "$config"
-                else
-                    sed -i '/"logo": {/,/}/ s/"type": ".*"/"type": "'"$LOGO_PROTOCOL"'"/' "$config"
-                    sed -i "s|\"source\": \"|\"source\": \"$tmp_dir/|g" "$config"
-                fi
+            # Ask for protocol once, then stay in preview loop
+            prompt_logo_protocol
+            while true; do
                 clear
-                echo -e "\033[1;33m--- Preview Mode (not applied) ---\033[0m"
-                fastfetch --config "$config" --show-errors
-                echo -e "\n\033[1;33m--- End of Preview ---\033[0m"
-                echo -e "\033[0;36mPress any key to return to menu...\033[0m"
-                read -r -n1
-                rm -rf "$tmp_dir"
-            else
-                echo -e "\033[1;31mInvalid theme number!\033[0m"
-                sleep 1
-            fi
+                echo -e "\033[1;33m--- Preview Mode (Protocol: $LOGO_PROTOCOL) -----------------------\033[0m"
+                for key in $(echo "${!THEMES[@]}" | tr ' ' '\n' | sort -n); do
+                    echo -e "  \e[1;34m[$key]\e[0;32m ${THEMES[$key]}\033[0m"
+                done
+                echo -e "\033[1;33m-------------------------------------------------------------------\033[0m"
+                echo -e "\033[0;36mType a number to preview · [C] change protocol · [Q] return to menu\033[0m"
+                echo -ne "\e[1;33mm3tozz\e[0;31m@\033[1;34mfastcat \033[1;31m(preview)\n\e[0;31m↳\e[1;36m "
+                read -r preview_input
+
+                case "$preview_input" in
+                    Q|q)
+                        clear
+                        break
+                        ;;
+                    C|c)
+                        prompt_logo_protocol
+                        ;;
+                    ''|*[!0-9]*)
+                        echo -e "\033[1;31mInvalid input!\033[0m"
+                        sleep 1
+                        ;;
+                    *)
+                        choice=$((10#$preview_input))
+                        if [[ -n "${THEMES[$choice]+x}" ]]; then
+                            local_theme="${THEMES[$choice]}"
+                            tmp_dir=$(mktemp -d)
+                            config="$tmp_dir/config.jsonc"
+                            cp -r "$local_theme/fastfetch/"* "$tmp_dir/"
+                            if [[ "$(uname)" == "Darwin" ]]; then
+                                sed -i '' '/"logo": {/,/}/s/"type": ".*"/"type": "'"$LOGO_PROTOCOL"'"/' "$config"
+                                sed -i '' "s|\"source\": \"|\"source\": \"$tmp_dir/|g" "$config"
+                            else
+                                sed -i '/"logo": {/,/}/ s/"type": ".*"/"type": "'"$LOGO_PROTOCOL"'"/' "$config"
+                                sed -i "s|\"source\": \"|\"source\": \"$tmp_dir/|g" "$config"
+                            fi
+                            clear
+                            echo -e "\033[1;33m--- Preview: $local_theme (not applied) ---\033[0m"
+                            fastfetch --config "$config" --show-errors
+                            echo -e "\n\033[1;33m--- End of Preview ---\033[0m"
+                            echo -e "\033[0;36mPress any key to continue...\033[0m"
+                            read -r -n1
+                            rm -rf "$tmp_dir"
+                        else
+                            echo -e "\033[1;31mTheme #$choice not found!\033[0m"
+                            sleep 1
+                        fi
+                        ;;
+                esac
+            done
             ;;
         D|d)
             echo -e "\n\033[1;33mWarning: There is no 'default' for visual themes.\033[0m"


### PR DESCRIPTION
### Problem

The current preview flow requires too many steps to browse themes:
1. Press `[P]` to enter preview
2. Enter a theme number
3. After viewing, get sent back to the main menu
4. Repeat from step 1 to see another theme

This makes it tedious to compare themes before committing to one.

### Solution

Replace the single-shot preview with a persistent **preview loop mode** that stays active until the user explicitly exits it.

**New flow:**
1. Press `[P]` from any theme menu (Small, Large or Visuals)
2. A preview menu appears listing all available themes with their numbers
3. Type a number → theme is previewed via `fastfetch --config`
4. After viewing, you're back in the preview menu (ready to pick the next one)
5. Press `[Q]` to exit preview mode and return to the main menu

**Visuals-Themes extra:** the image protocol (`kitty`, `iterm`, etc.) is asked **once** on entering preview mode. Press `[C]` at any point to change it without leaving the preview loop.

### Files changed
- `Small-Themes/start.sh`
- `Large-Themes/start.sh`
- `Visuals-Themes/start.sh`


<img width="1389" height="558" alt="image" src="https://github.com/user-attachments/assets/6a0b3dac-e1a2-4019-b562-798414cf1f26" />
